### PR TITLE
Use new Python API of OpenVINO

### DIFF
--- a/optimization/nebullvm/nebullvm/operations/inference_learners/openvino.py
+++ b/optimization/nebullvm/nebullvm/operations/inference_learners/openvino.py
@@ -20,7 +20,6 @@ from optimization.nebullvm.nebullvm.optional_modules.openvino import (
     Core,
     Model,
     CompiledModel,
-    InferRequest,
 )
 from nebullvm.optional_modules.tensorflow import tensorflow as tf
 from nebullvm.optional_modules.torch import torch
@@ -52,7 +51,6 @@ class OpenVinoInferenceLearner(BaseInferenceLearner, ABC):
     def __init__(
         self,
         compiled_model: CompiledModel,
-        infer_request: InferRequest,
         input_keys: List,
         output_keys: List,
         description_file: str,
@@ -62,7 +60,6 @@ class OpenVinoInferenceLearner(BaseInferenceLearner, ABC):
     ):
         super().__init__(**kwargs)
         self.compiled_model = compiled_model
-        self.infer_request = infer_request
         self.input_keys = input_keys
         self.output_keys = output_keys
         self.device = device
@@ -147,7 +144,6 @@ class OpenVinoInferenceLearner(BaseInferenceLearner, ABC):
             model.reshape(dynamic_shape)
 
         compiled_model = core.compile_model(model=model, device_name="CPU")
-        infer_request = compiled_model.create_infer_request()
 
         input_keys = list(
             map(lambda obj: obj.get_any_name(), compiled_model.inputs)
@@ -158,7 +154,6 @@ class OpenVinoInferenceLearner(BaseInferenceLearner, ABC):
 
         return cls(
             compiled_model,
-            infer_request,
             input_keys,
             output_keys,
             input_tfms=input_tfms,
@@ -240,18 +235,15 @@ class OpenVinoInferenceLearner(BaseInferenceLearner, ABC):
         input_arrays: Generator[np.ndarray, None, None],
     ) -> Generator[np.ndarray, None, None]:
 
-        results = self.infer_request.infer(
+        results = self.compiled_model(
             inputs={
                 input_key: input_array
                 for input_key, input_array in zip(
                     self.input_keys, input_arrays
                 )
-            }
+            },
+            shared_memory=True,  # always enabled
         )
-        results = {
-            output_key.get_any_name(): output_arr
-            for output_key, output_arr in results.items()
-        }
 
         return (results[output_key] for output_key in self.output_keys)
 


### PR DESCRIPTION
Updating OpenVINO to use new capabilities of [2023.0 release](https://pypi.org/project/openvino/2023.0.0/).

Applied changes:
* Remove `InferRequest` use in favor of direct `CompiledModel` calls. New class behavior create `InferRequest` on demand when inference is run for the first time and holds it internally. [More info here](https://docs.openvino.ai/2023.0/openvino_docs_OV_UG_Python_API_inference.html#direct-inference-with-compiledmodel).
* Use of new `shared_memory` mode to limit copies of input data. If project is implemented in a manner to run sequentially, it can be left as `True`. If not, the new mode can be exposed as additional flag to the wrapper method. [More on the feature here](https://docs.openvino.ai/2023.0/openvino_docs_OV_UG_Python_API_inference.html#shared-memory-on-inputs).
(note to maintainers: requires benchmarking on project's side)
* Address resulting dictionary directly with names. [More on `OVDict` here](https://docs.openvino.ai/2023.0/openvino_docs_OV_UG_Python_API_exclusives.html#inference-results-ovdict).

Thanks in advance for the review!